### PR TITLE
Optimized PacketReader() with DisplayLocation caching, and fixed bugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive",
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.spaff</groupId>
     <artifactId>TradeCenter</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>TradeCenter</name>

--- a/src/main/java/me/spaff/tradecenter/Constants.java
+++ b/src/main/java/me/spaff/tradecenter/Constants.java
@@ -1,6 +1,5 @@
 package me.spaff.tradecenter;
 
-import me.spaff.tradecenter.utils.StringUtils;
 import org.bukkit.Material;
 
 public class Constants {

--- a/src/main/java/me/spaff/tradecenter/Constants.java
+++ b/src/main/java/me/spaff/tradecenter/Constants.java
@@ -11,7 +11,7 @@ public class Constants {
     // Trade Center
     public static final String TRADE_CENTER_DATA_ID = "TradeCenter";
 
-    public static final Material TRADE_CENTER_BLOCK_TYPE = Material.BROWN_STAINED_GLASS;
+    public static final Material TRADE_CENTER_BLOCK_TYPE = Material.GLASS;
 
     public static final String TRADE_CENTER_NAMESPACE_KEY = "itemid";
     public static final String TRADE_CENTER_ITEM_ID = "tradecenter";

--- a/src/main/java/me/spaff/tradecenter/Constants.java
+++ b/src/main/java/me/spaff/tradecenter/Constants.java
@@ -11,7 +11,7 @@ public class Constants {
     // Trade Center
     public static final String TRADE_CENTER_DATA_ID = "TradeCenter";
 
-    public static final Material TRADE_CENTER_BLOCK_TYPE = Material.GLASS;
+    public static final Material TRADE_CENTER_BLOCK_TYPE = Material.BROWN_STAINED_GLASS;
 
     public static final String TRADE_CENTER_NAMESPACE_KEY = "itemid";
     public static final String TRADE_CENTER_ITEM_ID = "tradecenter";

--- a/src/main/java/me/spaff/tradecenter/Main.java
+++ b/src/main/java/me/spaff/tradecenter/Main.java
@@ -5,6 +5,7 @@ import me.spaff.tradecenter.config.Config;
 import me.spaff.tradecenter.listener.PlayerListener;
 import me.spaff.tradecenter.listener.ServerListener;
 import me.spaff.tradecenter.nms.PacketReader;
+import me.spaff.tradecenter.tradecenter.DisplayLocationCache;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
 import me.spaff.tradecenter.utils.RecipesUtils;
 import org.bukkit.Bukkit;
@@ -16,6 +17,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class Main extends JavaPlugin {
     public static final String version = "1.0.2";
     private static Main instance;
+    private static DisplayLocationCache displayCache;
 
     public Main() {
         instance = this;
@@ -29,6 +31,10 @@ public final class Main extends JavaPlugin {
     public void onEnable() {
         instance = this;
 
+        Config.load();
+
+        displayCache = new DisplayLocationCache(instance);
+
         registerListeners();
         registerCommands();
 
@@ -36,21 +42,21 @@ public final class Main extends JavaPlugin {
             PacketReader.uninjectPlayer(player);
             PacketReader.injectPlayer(player);
         });
-
-        Config.load();
+        
         registerRecipes();
     }
 
     @Override
     public void onDisable() {
-        instance = null;
+        displayCache.clearCache();
+        // instance = null; (doing this invalidates the packetReader and kicks players when the plugin unloads)
     }
 
     // Registers
 
     private void registerListeners() {
         Bukkit.getServer().getPluginManager().registerEvents(new PlayerListener(), this);
-        Bukkit.getServer().getPluginManager().registerEvents(new ServerListener(), this);
+        Bukkit.getServer().getPluginManager().registerEvents(new ServerListener(instance, displayCache), this);
     }
 
     private void registerCommands() {

--- a/src/main/java/me/spaff/tradecenter/Main.java
+++ b/src/main/java/me/spaff/tradecenter/Main.java
@@ -15,7 +15,7 @@ import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class Main extends JavaPlugin {
-    public static final String version = "1.0.2";
+    public static final String version = "1.1.0";
     private static Main instance;
     private static DisplayLocationCache displayCache;
 

--- a/src/main/java/me/spaff/tradecenter/Main.java
+++ b/src/main/java/me/spaff/tradecenter/Main.java
@@ -60,7 +60,7 @@ public final class Main extends JavaPlugin {
     }
 
     private void registerCommands() {
-        this.getCommand("tradecenter").setExecutor(new TCCommands());
+        this.getCommand("tradecenter").setExecutor(new TCCommands(displayCache));
     }
 
     private void registerRecipes() {

--- a/src/main/java/me/spaff/tradecenter/cmd/TCCommands.java
+++ b/src/main/java/me/spaff/tradecenter/cmd/TCCommands.java
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -24,33 +25,32 @@ public class TCCommands implements CommandExecutor {
         this.displayCache = displayCache;
     }
 
-    private void sendHelp(Player player) {
-        BukkitUtils.sendMessage(player, "");
-        BukkitUtils.sendMessage(player, TCColors.YELLOW + "                TradeCenter");
-        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW + "- /tc give <player> - gives player a trade");
-        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "center place item.");
-        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc reload - reloads the config.");
-        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc buildcache - adds loaded trade center block locations to cache.");
-        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc clearcache - clears the cache.");
-        BukkitUtils.sendMessage(player, "");
+    private void sendHelp(CommandSender sender) {
+        BukkitUtils.sendMessage(sender, "");
+        BukkitUtils.sendMessage(sender, TCColors.YELLOW + "                TradeCenter");
+        BukkitUtils.sendMessage(sender, TCColors.BRIGHT_YELLOW + "- /tc give <player> - gives player a trade");
+        BukkitUtils.sendMessage(sender, TCColors.BRIGHT_YELLOW  + "center place item.");
+        BukkitUtils.sendMessage(sender, TCColors.BRIGHT_YELLOW  + "- /tc reload - reloads the config.");
+        BukkitUtils.sendMessage(sender, TCColors.BRIGHT_YELLOW  + "- /tc buildcache - adds loaded trade center block locations to cache.");
+        BukkitUtils.sendMessage(sender, TCColors.BRIGHT_YELLOW  + "- /tc clearcache - clears the cache.");
+        BukkitUtils.sendMessage(sender, "");
     }
 
-    private void sendPluginMessage(Player player, String message) {
-        BukkitUtils.sendMessage(player, prefix + message);
+    private void sendPluginMessage(CommandSender sender, String message) {
+        BukkitUtils.sendMessage(sender, prefix + message);
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!(sender instanceof Player)) return false;
+        if (!(sender instanceof Player) && !(sender instanceof ConsoleCommandSender)) return false;
 
-        Player player = (Player) sender;
         if (args.length == 0) {
-            sendHelp(player);
+            sendHelp(sender);
             return false;
         }
 
-        if (!player.hasPermission(Constants.COMMAND_PERMISSION)) {
-            BukkitUtils.sendMessage(player, Config.readString("trade-center.message.execute-cmd-no-permission"));
+        if (!sender.hasPermission(Constants.COMMAND_PERMISSION)) {
+            BukkitUtils.sendMessage(sender, Config.readString("trade-center.message.execute-cmd-no-permission"));
             return false;
         }
 
@@ -60,16 +60,17 @@ public class TCCommands implements CommandExecutor {
             if (args.length == 2) {
                 Player otherPlayer = Bukkit.getPlayer(args[1]);
                 if (otherPlayer == null) {
-                    sendPluginMessage(player, "&cInvalid player!");
+                    sendPluginMessage(sender, "&cInvalid player!");
                     return false;
                 }
 
                 otherPlayer.getInventory().addItem(TradeCenter.getTradeCenterItem());
-                sendPluginMessage(player, "&7Gave " + otherPlayer.getName() + " trade center item.");
+                sendPluginMessage(sender, "&7Gave " + otherPlayer.getName() + " trade center item.");
             }
-            else {
+            else if (sender instanceof Player) {
+                Player player = (Player) sender;
                 player.getInventory().addItem(TradeCenter.getTradeCenterItem());
-                sendPluginMessage(player, "&7Gave yourself trade center item.");
+                sendPluginMessage(sender, "&7Gave yourself trade center item.");
             }
         }
         else if (args[0].equalsIgnoreCase("reload")) {
@@ -77,24 +78,24 @@ public class TCCommands implements CommandExecutor {
             Config.reload();
 
             if (oldData == null || oldData.isEmpty() || Config.getRawData() == null || Config.getRawData().isEmpty()) {
-                sendPluginMessage(player, "&cSomething went wrong when reloading the config!");
+                sendPluginMessage(sender, "&cSomething went wrong when reloading the config!");
             }
             else
-                sendPluginMessage(player, "&7Config reloaded successfully!");
+                sendPluginMessage(sender, "&7Config reloaded successfully!");
         }
         else if (args[0].equalsIgnoreCase("version")) {
-            sendPluginMessage(player, "&7Version: &fv" + Main.version);
+            sendPluginMessage(sender, "&7Version: &fv" + Main.version);
         }
         else if (args[0].equalsIgnoreCase("buildcache")) {
-            sendPluginMessage(player, "&7Building DisplayLocactionCache..!" );
+            sendPluginMessage(sender, "&7Building DisplayLocactionCache..!" );
             displayCache.buildCache();
         }
         else if (args[0].equalsIgnoreCase("clearcache")) {
-            sendPluginMessage(player, "&7Clearing DisplayLocactionCache..!" );
+            sendPluginMessage(sender, "&7Clearing DisplayLocactionCache..!" );
             displayCache.clearCache();
         }
         else
-            sendHelp(player);
+            sendHelp(sender);
 
         return true;
     }

--- a/src/main/java/me/spaff/tradecenter/cmd/TCCommands.java
+++ b/src/main/java/me/spaff/tradecenter/cmd/TCCommands.java
@@ -7,7 +7,6 @@ import me.spaff.tradecenter.config.Config;
 import me.spaff.tradecenter.tradecenter.DisplayLocationCache;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
 import me.spaff.tradecenter.utils.BukkitUtils;
-import me.spaff.tradecenter.utils.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/me/spaff/tradecenter/cmd/TCCommands.java
+++ b/src/main/java/me/spaff/tradecenter/cmd/TCCommands.java
@@ -4,6 +4,7 @@ import me.spaff.tradecenter.Constants;
 import me.spaff.tradecenter.Main;
 import me.spaff.tradecenter.TCColors;
 import me.spaff.tradecenter.config.Config;
+import me.spaff.tradecenter.tradecenter.DisplayLocationCache;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
 import me.spaff.tradecenter.utils.BukkitUtils;
 import me.spaff.tradecenter.utils.StringUtils;
@@ -17,6 +18,11 @@ import java.util.HashMap;
 
 public class TCCommands implements CommandExecutor {
     private final String prefix = TCColors.YELLOW + "[TradeCenter] ";
+    private DisplayLocationCache displayCache;
+
+    public TCCommands(DisplayLocationCache displayCache) {
+        this.displayCache = displayCache;
+    }
 
     private void sendHelp(Player player) {
         BukkitUtils.sendMessage(player, "");
@@ -24,7 +30,8 @@ public class TCCommands implements CommandExecutor {
         BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW + "- /tc give <player> - gives player a trade");
         BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "center place item.");
         BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc reload - reloads the config.");
-        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc version - shows version of the plugin.");
+        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc buildcache - adds loaded trade center block locations to cache.");
+        BukkitUtils.sendMessage(player, TCColors.BRIGHT_YELLOW  + "- /tc clearcache - clears the cache.");
         BukkitUtils.sendMessage(player, "");
     }
 
@@ -77,6 +84,14 @@ public class TCCommands implements CommandExecutor {
         }
         else if (args[0].equalsIgnoreCase("version")) {
             sendPluginMessage(player, "&7Version: &fv" + Main.version);
+        }
+        else if (args[0].equalsIgnoreCase("buildcache")) {
+            sendPluginMessage(player, "&7Building DisplayLocactionCache..!" );
+            displayCache.buildCache();
+        }
+        else if (args[0].equalsIgnoreCase("clearcache")) {
+            sendPluginMessage(player, "&7Clearing DisplayLocactionCache..!" );
+            displayCache.clearCache();
         }
         else
             sendHelp(player);

--- a/src/main/java/me/spaff/tradecenter/listener/PlayerListener.java
+++ b/src/main/java/me/spaff/tradecenter/listener/PlayerListener.java
@@ -6,6 +6,8 @@ import me.spaff.tradecenter.config.Config;
 import me.spaff.tradecenter.nms.PacketReader;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
 import me.spaff.tradecenter.utils.*;
+
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -74,6 +76,10 @@ public class PlayerListener implements Listener {
         if (!ItemUtils.isNull(itemUsed) && TradeCenter.isTradeCenterItem(itemUsed)) {
             block.setType(Constants.TRADE_CENTER_BLOCK_TYPE);
             new TradeCenter(block.getLocation()).onPlace();
+
+            if (0>block.getLocation().getY()||block.getLocation().getY()>=256) {
+                e.getPlayer().sendMessage(ChatColor.RED + "Due to Bukkit limitations, you will have trouble seeing Trade Center blocks below y=0 and above y=255. Remember that the trade center block is brown stained glass!");
+            }
         }
     }
 

--- a/src/main/java/me/spaff/tradecenter/listener/PlayerListener.java
+++ b/src/main/java/me/spaff/tradecenter/listener/PlayerListener.java
@@ -7,7 +7,6 @@ import me.spaff.tradecenter.nms.PacketReader;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
 import me.spaff.tradecenter.utils.*;
 
-import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -76,10 +75,6 @@ public class PlayerListener implements Listener {
         if (!ItemUtils.isNull(itemUsed) && TradeCenter.isTradeCenterItem(itemUsed)) {
             block.setType(Constants.TRADE_CENTER_BLOCK_TYPE);
             new TradeCenter(block.getLocation()).onPlace();
-
-            if (0>block.getLocation().getY()||block.getLocation().getY()>=256) {
-                e.getPlayer().sendMessage(ChatColor.RED + "Due to Bukkit limitations, you will have trouble seeing Trade Center blocks below y=0 and above y=255. Remember that the trade center block is brown stained glass!");
-            }
         }
     }
 

--- a/src/main/java/me/spaff/tradecenter/listener/ServerListener.java
+++ b/src/main/java/me/spaff/tradecenter/listener/ServerListener.java
@@ -1,14 +1,32 @@
 package me.spaff.tradecenter.listener;
 
+import me.spaff.tradecenter.config.Config;
+import me.spaff.tradecenter.tradecenter.DisplayLocationCache;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.plugin.Plugin;
 
 public class ServerListener implements Listener {
+    private final Plugin plugin;
+    public DisplayLocationCache displayCache;
+
+    public ServerListener(Plugin plugin, DisplayLocationCache displayCache) {
+        this.plugin = plugin;
+        this.displayCache = displayCache;
+    }
+
     @EventHandler
     public void onBlockPistonExtendEvent(BlockPistonExtendEvent e) {
         for (Block block : e.getBlocks()) {
@@ -32,6 +50,38 @@ public class ServerListener implements Listener {
         for (Block block : e.blockList()) {
             if (!TradeCenter.isTradeCenter(block)) continue;
             new TradeCenter(block.getLocation()).clearData();
-        }
+        } 
+    }
+
+    @EventHandler
+    public void onChunkLoad(ChunkLoadEvent e) {
+        Integer radius = Config.readInt("trade-center.display-cache.chunk-listener-radius");
+        if (radius==null || radius<0) return;
+
+        Chunk centerChunk = e.getChunk();
+        boolean pass = false;
+        for (Entity entity : centerChunk.getEntities()) {
+            if (entity instanceof Player) {
+                pass = true;
+                break;
+            }
+        } if (!pass) return;
+
+        final int scanRadius = radius;
+        World world = centerChunk.getWorld();
+        int centerX = centerChunk.getX();
+        int centerZ = centerChunk.getZ();
+                
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            // Iterate over all chunks within the specified radius
+            for (int xOffset = -scanRadius; xOffset <= scanRadius; xOffset++) {
+                for (int zOffset = -scanRadius; zOffset <= scanRadius; zOffset++) {
+                    Chunk currentChunk = world.getChunkAt(centerX + xOffset, centerZ + zOffset);
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        displayCache.scanChunkForTradeCenters(world, currentChunk);
+                    }, 1);
+                }
+            }
+        }, 1);
     }
 }

--- a/src/main/java/me/spaff/tradecenter/nms/DisplayEntity.java
+++ b/src/main/java/me/spaff/tradecenter/nms/DisplayEntity.java
@@ -276,7 +276,7 @@ public class DisplayEntity {
 
         public void updateDisplayContext(DisplayContext context) {
             for (Player player : Bukkit.getOnlinePlayers()) {
-                updateDisplayContext(context);
+                updateDisplayContext(player, context);
             }
         }
 

--- a/src/main/java/me/spaff/tradecenter/nms/PacketReader.java
+++ b/src/main/java/me/spaff/tradecenter/nms/PacketReader.java
@@ -1,9 +1,7 @@
 package me.spaff.tradecenter.nms;
 
 import io.netty.channel.*;
-import me.spaff.tradecenter.Constants;
 import me.spaff.tradecenter.Main;
-import me.spaff.tradecenter.chunkdata.ChunkData;
 import me.spaff.tradecenter.tradecenter.TradeCenter;
 import me.spaff.tradecenter.utils.ReflectionUtils;
 import net.minecraft.network.Connection;

--- a/src/main/java/me/spaff/tradecenter/nms/PacketReader.java
+++ b/src/main/java/me/spaff/tradecenter/nms/PacketReader.java
@@ -46,7 +46,7 @@ public class PacketReader {
 
                             // world.getChunkAt(chunkX, chunkZ).getTileEntities()
                             for (int x = 0; x < 16; x++) {
-                                for (int y = 0; y < 319; y++) {
+                                for (int y = 0; y < 255; y++) {
                                     for (int z = 0; z < 16; z++) {
                                         if (chunkSnapshot.getBlockType(x, y, z) != Constants.TRADE_CENTER_BLOCK_TYPE) continue;
                                         ChunkData chunkData = new ChunkData(chunk.getBlock(x, y, z)); // Check if correct chunk block coords

--- a/src/main/java/me/spaff/tradecenter/tradecenter/DisplayLocationCache.java
+++ b/src/main/java/me/spaff/tradecenter/tradecenter/DisplayLocationCache.java
@@ -1,0 +1,117 @@
+package me.spaff.tradecenter.tradecenter;
+
+import me.spaff.tradecenter.config.Config;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DisplayLocationCache {
+    // Key: "chunkX-chunkZ", Value: List of trade center locations in that chunk
+    private static final Map<String, List<Location>> cache = new ConcurrentHashMap<>();
+    private final Plugin plugin;
+
+    /**
+     * Constructor schedules a repeating task that updates cache every 15 seconds
+     */
+    public DisplayLocationCache(Plugin plugin) {
+        this.plugin = plugin;
+
+        Integer seconds = Config.readInt("trade-center.display-cache.auto-reloader-timer");
+        if (seconds==null || seconds<0) return;
+
+        Integer radius = Config.readInt("trade-center.display-cache.auto-reloader-radius");
+        if (radius==null || radius<0) return;
+
+        Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+            updateCacheForOnlinePlayers(radius);
+        }, 0L, 20L*seconds);
+    }
+
+    public void updateCacheForOnlinePlayers(int radius) {
+        final int scanRadius = radius;
+
+        Set<Chunk> uniqueChunks = new HashSet<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            Chunk centerChunk = player.getLocation().getChunk();
+
+            World world = centerChunk.getWorld();
+            int centerX = centerChunk.getX();
+            int centerZ = centerChunk.getZ();
+
+            for (int xOffset = -scanRadius; xOffset <= scanRadius; xOffset++) {
+                for (int zOffset = -scanRadius; zOffset <= scanRadius; zOffset++) {
+                    Chunk currentChunk = world.getChunkAt(centerX + xOffset, centerZ + zOffset);
+                    uniqueChunks.add(currentChunk);
+                }
+            }
+        }
+
+        int delay = 1;
+        for (Chunk chunk : uniqueChunks) {
+            World world = chunk.getWorld();
+            // Schedule each chunk scan on a slight delay to avoid blocking the main thread all at once
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                scanChunkForTradeCenters(world, chunk);
+            }, delay++);
+        }
+    }
+
+    public void scanChunkForTradeCenters(World world, Chunk chunk) {
+        for (int x = 0; x < 16; x++) {
+            for (int y = world.getMinHeight(); y < world.getMaxHeight(); y++) {
+                for (int z = 0; z < 16; z++) {
+                    Block block = chunk.getBlock(x, y, z);
+                    if (TradeCenter.isTradeCenter(block)) {
+                        addDisplayLocation(block.getLocation());
+                        plugin.getLogger().info("Display @ " + chunk.getWorld().getName() + ": " + x + ", " + y + ", " + z);
+                    }
+                }
+            }
+        }
+    }
+
+    public void clearCache() {
+        cache.clear();
+    }
+
+    public static void addDisplayLocation(Location loc) {
+        String key = getChunkKey(loc);
+        cache.computeIfAbsent(key, k -> new ArrayList<>()).add(loc);
+    }
+
+    public static void removeDisplayLocation(Location loc) {
+        String key = getChunkKey(loc);
+        List<Location> locations = cache.get(key);
+        if (locations != null) {
+            locations.removeIf(savedLoc -> savedLoc.equals(loc));
+            if (locations.isEmpty()) {
+                cache.remove(key);
+            }
+        }
+    }
+
+    public static void removeDisplayLocationsByChunk(String key) {
+        cache.remove(key);
+    }
+
+    public static List<Location> getDisplayLocationsByChunk(String chunkKey) {
+        return cache.get(chunkKey);
+    }
+
+    // Create key from chunk coordinates
+    private static String getChunkKey(Location loc) {
+        return loc.getChunk().getX() + "-" + loc.getChunk().getZ();
+    }
+}

--- a/src/main/java/me/spaff/tradecenter/tradecenter/TradeCenter.java
+++ b/src/main/java/me/spaff/tradecenter/tradecenter/TradeCenter.java
@@ -163,7 +163,6 @@ public class TradeCenter {
     public static void handleClickEvent(InventoryClickEvent e) {
         Player player = (Player) e.getWhoClicked();
         if (e.getClickedInventory() == null) return;
-        if (TradeCenter.getPlayerData(player) == null) return; // Player clicked normal trade menu
 
         Inventory clickedInventory = e.getClickedInventory();
         if (!clickedInventory.getType().equals(InventoryType.MERCHANT)) return;
@@ -177,8 +176,16 @@ public class TradeCenter {
         if (ItemUtils.isNull(resultItem)) return;
         if (isShiftClick && !InventoryUtils.canFitItem(player, resultItem)) return;
 
+        Optional<PlayerTradeCenterData> optionalData = TradeCenter.getPlayerData(player);
+        if (!optionalData.isPresent()) {
+            System.out.println("optional data not present for player " + player.getName());
+            return;
+        }
+
+        PlayerTradeCenterData tradeCenterData = optionalData.get();
+
         // Get selected trade from the menu
-        int selectedTradeIndex = TradeCenter.getPlayerData(player).orElseThrow().getSelectedTrade(); // getSelectedTrade()
+        int selectedTradeIndex = tradeCenterData.getSelectedTrade(); // getSelectedTrade()
 
         // Get player's TRADED_WITH_VILLAGER statistic so we can later tell
         // how many times player traded something
@@ -186,13 +193,13 @@ public class TradeCenter {
 
         // Get trade center location so we can later drop
         // experience orbs after a trade
-        Location tradeCenterLoc = TradeCenter.getPlayerData(player).orElseThrow().getTradeLocation();
+        Location tradeCenterLoc = tradeCenterData.getTradeLocation();
 
-        System.out.println("player data: " + TradeCenter.getPlayerData(player).orElseThrow().getTradeData());
+        System.out.println("player data: " + tradeCenterData.getTradeData());
 
         boolean breakOut = false;
         int tradesAmount = 0;
-        for (VillagerTradeData data : TradeCenter.getPlayerData(player).orElseThrow().getTradeData()) {
+        for (VillagerTradeData data :tradeCenterData.getTradeData()) {
             Villager villager = data.villager();
 
             System.out.println("player data");

--- a/src/main/java/me/spaff/tradecenter/tradecenter/TradeCenter.java
+++ b/src/main/java/me/spaff/tradecenter/tradecenter/TradeCenter.java
@@ -301,7 +301,7 @@ public class TradeCenter {
     }
 
     public static boolean isTradeCenter(Block block) {
-        return new ChunkData(block).getData() != null;
+        return Constants.TRADE_CENTER_DATA_ID.equals(new ChunkData(block).getData());
     }
 
     // Player Data

--- a/src/main/java/me/spaff/tradecenter/tradecenter/TradeCenter.java
+++ b/src/main/java/me/spaff/tradecenter/tradecenter/TradeCenter.java
@@ -55,14 +55,20 @@ public class TradeCenter {
 
         // Save persistent data
         saveData();
+
+        // Add location to cache
+        me.spaff.tradecenter.tradecenter.DisplayLocationCache.addDisplayLocation(location);
     }
 
     public void onBreak() {
+        // Remove location from cache
+        me.spaff.tradecenter.tradecenter.DisplayLocationCache.removeDisplayLocation(location);
+
         // Close trade menu for player using it
         beingUsedBy().ifPresent((player) -> player.closeInventory());
 
         // Clear model data
-        clearModels();
+        clearModel();
 
         // Clear persistent data
         clearData();
@@ -344,14 +350,14 @@ public class TradeCenter {
         }
     }
 
-    public void clearModels() {
+    public void clearModel() {
         Bukkit.getOnlinePlayers().forEach((player) -> {
-            clearModels(player);
+            clearModel(player);
         });
         modelData.remove(location);
     }
 
-    public void clearModels(Player player) {
+    public void clearModel(Player player) {
         // Clear old model data for player so the models
         // don't pile up and eventually lag player's game
         if (modelData.get(location) == null) return;

--- a/src/main/java/me/spaff/tradecenter/utils/BukkitUtils.java
+++ b/src/main/java/me/spaff/tradecenter/utils/BukkitUtils.java
@@ -2,11 +2,11 @@ package me.spaff.tradecenter.utils;
 
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 
 public class BukkitUtils {
-    public static void sendMessage(Player player, String message) {
-        player.sendMessage(StringUtils.getColoredText(message));
+    public static void sendMessage(CommandSender sender, String message) {
+        sender.sendMessage(StringUtils.getColoredText(message));
     }
 
     public static boolean isSameLocation(Location loc1, Location loc2) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,3 +9,7 @@ trade-center:
     already-in-use: "&cThis trade center is currently being used by another player!"
     no-villagers-nearby: "&cThere are no nearby villagers!"
     invalid-trade: "&cThis trade no longer exists!"
+  display-cache:
+    auto-reloader-timer: 5
+    auto-reloader-radius: 2 # -1 to disable
+    chunk-listener-radius: 2 # -1 to disable

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TradeCenter
-version: '1.0.2'
+version: '1.1.0'
 main: me.spaff.tradecenter.Main
 api-version: '1.21'
 authors: [ spaff ]


### PR DESCRIPTION
- Implemented DisplayLocationCache which uses a ConcurrentHashMap to store trade center locations keyed by chunk coordinates:
  - has configurable repeating task to automatically scan chunks nearby online players
  - has configurable ChunkLoadEvent listener to automatically scan chunks nearby online players
- Optimized PacketReader by using new cached locations instead of checking every block, in every chunk, every time, which was incredibly intensive.
- Fixed display errors when chunks are below y=0 and above y=255.
- Fixed no optional data error in TradeCenter.handleClickEvent().